### PR TITLE
Update MovieRouter to use MovieOperations instead.

### DIFF
--- a/Operations/MovieOperations.cs
+++ b/Operations/MovieOperations.cs
@@ -6,10 +6,11 @@ namespace Operations;
 
 public interface IMovieOperations
 {
-    public Task<Movie> AddMovie(Movie movie);
-    public Task<Movie?> DeleteMovie(Guid id);
-    public Task<Movie?> GetMovie(Guid id);
-    public Task<IEnumerable<Movie>> GetMovies();
+    public Task<Movie> AddMovieAsync(Movie movie);
+    public Task<Movie?> DeleteMovieAsync(Guid id);
+    public Task<Movie?> GetMovieAsync(Guid id);
+    public Task<Movie?> UpdateMovieAsync(Movie movie);
+    public Task<IEnumerable<Movie>> GetMoviesAsync();
 }
 
 public class MovieOperations : IMovieOperations
@@ -21,7 +22,7 @@ public class MovieOperations : IMovieOperations
         _context = context;
     }
 
-    public async Task<Movie> AddMovie(Movie movie)
+    public async Task<Movie> AddMovieAsync(Movie movie)
     {
         _context.Movies.Add(movie);
         await _context.SaveChangesAsync();
@@ -29,7 +30,7 @@ public class MovieOperations : IMovieOperations
         return movie;
     }
 
-    public async Task<Movie?> DeleteMovie(Guid id)
+    public async Task<Movie?> DeleteMovieAsync(Guid id)
     {
         if (await _context.Movies.FindAsync(id) is Movie movie)
         {
@@ -42,7 +43,25 @@ public class MovieOperations : IMovieOperations
         return null;
     }
 
-    public async Task<Movie?> GetMovie(Guid id)
+    public async Task<Movie?> UpdateMovieAsync(Movie movie)
+    {
+         var originalMovie = await _context.Movies.FindAsync(movie.Id);
+
+        if (originalMovie is null) return null;
+
+        originalMovie.Title = movie.Title;
+        originalMovie.Description = movie.Description;
+        originalMovie.ReleaseDate = movie.ReleaseDate;
+        originalMovie.Rating = movie.Rating;
+        originalMovie.Description = movie.Description;
+        originalMovie.InventoryDate = movie.InventoryDate;
+
+        await _context.SaveChangesAsync();
+
+        return movie;
+    }
+
+    public async Task<Movie?> GetMovieAsync(Guid id)
     {
         return await _context.Movies.FindAsync(id)
             is Movie movie
@@ -50,7 +69,7 @@ public class MovieOperations : IMovieOperations
                 : null;
     }
 
-    public async Task<IEnumerable<Movie>> GetMovies()
+    public async Task<IEnumerable<Movie>> GetMoviesAsync()
     {
         return await _context.Movies.ToArrayAsync();
     }


### PR DESCRIPTION
As the title suggests, this updates the router for Movies to instead use calls to an operation class for Movies. This lets us more cleanly use DI for things, and makes the actions for handling movies in the DB more portable if needed. Once testing is added we can also independently test the actions of handling data and simply returning data.